### PR TITLE
fix: capitalize Zondax in package.json GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zondax/ledger-peaq-js.git"
+    "url": "git+https://github.com/Zondax/ledger-peaq-js.git"
   },
   "keywords": [
     "Ledger",
@@ -16,9 +16,9 @@
   "author": "Zondax GmbH",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/zondax/ledger-peaq-js/issues"
+    "url": "https://github.com/Zondax/ledger-peaq-js/issues"
   },
-  "homepage": "https://github.com/zondax/ledger-peaq-js",
+  "homepage": "https://github.com/Zondax/ledger-peaq-js",
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^6.46.1",
     "@zondax/ledger-js": "^1.3.1",


### PR DESCRIPTION
Required for OIDC trusted publishing: npm's sigstore provenance verifier
case-sensitively compares package.json's repository.url / bugs.url / homepage
against the GitHub provenance attestation (Zondax/ledger-peaq-js) and rejects
publish with 422 when they differ:

  422 Unprocessable Entity ... Error verifying sigstore provenance bundle:
  Failed to validate repository information: package.json: "repository.url"
  is "git+https://github.com/zondax/ledger-peaq-js.git", expected to match
  "https://github.com/Zondax/ledger-peaq-js" from provenance.

(This fix was on the OIDC PR #8 branch but landed there after #8 was already
merged, so it never reached main. Re-doing as its own PR.)
